### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -98,10 +98,15 @@ export class WebFetchTool extends BaseTool<WebFetchToolParams, ToolResult> {
     let url = urls[0];
 
     // Convert GitHub blob URL to raw URL
-    if (url.includes('github.com') && url.includes('/blob/')) {
-      url = url
-        .replace('github.com', 'raw.githubusercontent.com')
-        .replace('/blob/', '/');
+    try {
+      const parsedUrl = new URL(url);
+      if (parsedUrl.host === 'github.com' && url.includes('/blob/')) {
+        url = url
+          .replace('github.com', 'raw.githubusercontent.com')
+          .replace('/blob/', '/');
+      }
+    } catch (error) {
+      throw new Error(`Invalid URL: ${url}`);
     }
 
     try {


### PR DESCRIPTION
Potential fix for [https://github.com/AKA-NETWORK/gemini-cli/security/code-scanning/1](https://github.com/AKA-NETWORK/gemini-cli/security/code-scanning/1)

To fix the issue, the code should parse the URL and validate its host explicitly instead of relying on a substring check. This can be achieved using the `URL` class available in modern JavaScript environments. The `URL` class allows extracting the `host` property of a URL, which can then be compared against the expected value (`github.com`). This ensures that only URLs with the correct host are processed.

**Steps to fix:**
1. Replace the `url.includes('github.com')` check with a parsed URL host comparison using the `URL` class.
2. Ensure that invalid or malformed URLs are handled gracefully by wrapping the parsing logic in a `try-catch` block.
3. Update the logic to only transform URLs where the host is exactly `github.com`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
